### PR TITLE
Add telegram provider for logging

### DIFF
--- a/telegram_provider.go
+++ b/telegram_provider.go
@@ -1,0 +1,67 @@
+package logger
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+)
+
+const PROVIDER_TELEGRAM = "telegram"
+
+type TelegramProvider struct {
+	url     string
+	chatIds []string
+}
+
+func NewTelegramProvider(url string, chatIds []string) (*TelegramProvider, error) {
+
+	if len(url) == 0 {
+		return nil, errors.New("Empty telegram url.")
+	} else if chatIds == nil {
+		return nil, errors.New("Empty telegram chat ids.")
+	}
+
+	provider := &TelegramProvider{
+		url:     url,
+		chatIds: chatIds,
+	}
+
+	return provider, nil
+}
+
+func (p TelegramProvider) GetID() string {
+	return PROVIDER_TELEGRAM
+}
+
+func (p TelegramProvider) Log(msg []byte) {
+	p.send("Log message\n", msg)
+}
+
+func (p TelegramProvider) Error(msg []byte) {
+	p.send("Error message\n", msg)
+}
+
+func (p TelegramProvider) Fatal(msg []byte) {
+	p.send("Fatal message\n", msg)
+}
+
+func (p TelegramProvider) Debug(msg []byte) {
+	p.send("Debug message\n", msg)
+}
+
+func (p TelegramProvider) send(subject string, body []byte) {
+	go tg_send(p.url, p.chatIds, subject, body)
+}
+
+func tg_send(url string, chatIds []string, subject string, body []byte) {
+	for _, chatId := range chatIds {
+		msg := "{\"chat_id\":" + chatId + ",\"text\":" + "\"" + subject + string(body) + "\"" + "}"
+		var jsonStr = []byte(msg)
+		req, _ := http.NewRequest("POST", url, bytes.NewBuffer(jsonStr))
+		req.Header.Set("Content-Type", "application/json")
+
+		client := &http.Client{}
+		resp, _ := client.Do(req)
+		defer resp.Body.Close()
+	}
+}

--- a/telegram_provider.go
+++ b/telegram_provider.go
@@ -34,19 +34,19 @@ func (p TelegramProvider) GetID() string {
 }
 
 func (p TelegramProvider) Log(msg []byte) {
-	p.send("Log message\n", msg)
+	p.send("Log message", msg)
 }
 
 func (p TelegramProvider) Error(msg []byte) {
-	p.send("Error message\n", msg)
+	p.send("Error message", msg)
 }
 
 func (p TelegramProvider) Fatal(msg []byte) {
-	p.send("Fatal message\n", msg)
+	p.send("Fatal message", msg)
 }
 
 func (p TelegramProvider) Debug(msg []byte) {
-	p.send("Debug message\n", msg)
+	p.send("Debug message", msg)
 }
 
 func (p TelegramProvider) send(subject string, body []byte) {
@@ -54,13 +54,22 @@ func (p TelegramProvider) send(subject string, body []byte) {
 }
 
 func tg_send(url string, chatIds []string, subject string, body []byte) {
-	for _, chatId := range chatIds {
-		msg := "{\"chat_id\":" + chatId + ",\"text\":" + "\"" + subject + string(body) + "\"" + "}"
-		var jsonStr = []byte(msg)
+	msg := map[string]interface{}{
+		"chat_id": "",
+		"text": subject + "\n" + string(body),
+	}
+	client := &http.Client{}
+	
+	for _, chatId := range chatIds {	
+		msg["chat_id"] = chatId
+		jsonStr, err := json.Marshal(msg)
+		if err != nil {
+			return;
+		}
+		
 		req, _ := http.NewRequest("POST", url, bytes.NewBuffer(jsonStr))
 		req.Header.Set("Content-Type", "application/json")
 
-		client := &http.Client{}
 		resp, _ := client.Do(req)
 		defer resp.Body.Close()
 	}


### PR DESCRIPTION
Для отправки сообщения через телеграм необходимо передать url вида https://api.telegram.org/bot_token/sendMessage, где bot_token это токен бота, перед которым следует слово bot и список получателей(их chatid в телеграме).
Пример отправки
url := "https://api.telegram.org/botXXXXXXXXXX/sendMessage"
tgIds := make([]string, 2)
tgIds[0] = "XXXXXXXX"
tgIds[1] = "XXXXXXXX"
tp, err := logger.NewTelegramProvider(url, tgIds)

if err != nil {
	panic(err)
}

LOGGER = logger.NewLogger()
LOGGER.RegisterProvider(tp)
LOGGER.AddLogProvider(tp.GetID())
LOGGER.AddErrorProvider(tp.GetID())
LOGGER.AddFatalProvider(tp.GetID())
LOGGER.AddDebugProvider(tp.GetID())
LOGGER.SetLevel(2)
LOGGER.Debug("test debug")
LOGGER.Log("test log")
LOGGER.Error("test error")